### PR TITLE
refactor: replace genesis_agents imports with dynamus_agent

### DIFF
--- a/dynamus-agent/src/dynamus_agent/agents/agent_base.py
+++ b/dynamus-agent/src/dynamus_agent/agents/agent_base.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/base/genesis_agent.py
+# src/dynamus_agent/agents/agent_base.py
 """
 Clase base para todos los agentes Genesis - Hub Independiente
 
@@ -51,7 +51,7 @@ except ImportError:
 
 # Imports locales (se crearán después)
 try:
-    from genesis_agents.base.capabilities import AgentCapability
+    from dynamus_agent.agents.capabilities import AgentCapability
 except ImportError:
     # Fallback temporal para desarrollo
     class AgentCapability(str, Enum):
@@ -59,9 +59,9 @@ except ImportError:
         API_GENERATION = "api_generation"
 
 try:
-    from genesis_agents.base.exceptions import (
-        AgentException, 
-        TaskExecutionError, 
+    from dynamus_agent.agents.exceptions import (
+        AgentException,
+        TaskExecutionError,
         AgentInitializationError,
         TaskTimeoutError,
         AgentOverloadError,

--- a/dynamus-agent/src/dynamus_agent/agents/capabilities.py
+++ b/dynamus-agent/src/dynamus_agent/agents/capabilities.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/base/capabilities.py
+# src/dynamus_agent/agents/capabilities.py
 """
 Definición de capacidades de agentes Genesis - Hub Independiente
 

--- a/dynamus-agent/src/dynamus_agent/agents/exceptions.py
+++ b/dynamus-agent/src/dynamus_agent/agents/exceptions.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/base/exceptions.py
+# src/dynamus_agent/agents/exceptions.py
 """
 Excepciones específicas para agentes Genesis
 """

--- a/dynamus-agent/src/dynamus_agent/registry/__init__.py
+++ b/dynamus-agent/src/dynamus_agent/registry/__init__.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/__init__.py
+# src/dynamus_agent/registry/__init__.py
 """
 Genesis Agents - Independent Hub for Genesis Engine Ecosystem
 
@@ -12,8 +12,8 @@ Key Components:
 - AgentDiscovery: Discovery strategies for ecosystem agents
 
 Usage:
-    from genesis_agents import GenesisAgent, AgentCapability
-    from genesis_agents.registry import GenesisAgentRegistry
+    from dynamus_agent import GenesisAgent, AgentCapability
+    from dynamus_agent.registry import GenesisAgentRegistry
     
     # Create custom agent
     class MyAgent(GenesisAgent):
@@ -39,7 +39,7 @@ __author__ = "Genesis Team"
 __email__ = "team@genesis-engine.dev"
 
 # Core exports
-from genesis_agents.base.genesis_agent import (
+from dynamus_agent.agents.agent_base import (
     GenesisAgent,
     AgentTask,
     TaskResult,
@@ -48,7 +48,7 @@ from genesis_agents.base.genesis_agent import (
     ExampleGenesisAgent  # For testing/examples only
 )
 
-from genesis_agents.base.capabilities import (
+from dynamus_agent.agents.capabilities import (
     AgentCapability,
     CapabilityCategory,
     get_capabilities_by_category,
@@ -57,7 +57,7 @@ from genesis_agents.base.capabilities import (
     COMMON_AGENT_CAPABILITIES
 )
 
-from genesis_agents.base.exceptions import (
+from dynamus_agent.agents.exceptions import (
     AgentException,
     AgentInitializationError,
     TaskExecutionError,
@@ -70,8 +70,8 @@ from genesis_agents.base.exceptions import (
 )
 
 # Registry exports
-from genesis_agents.registry.agent_registry import GenesisAgentRegistry
-from genesis_agents.registry.discovery import (
+from dynamus_agent.registry.agent_registry import GenesisAgentRegistry
+from dynamus_agent.registry.discovery import (
     AgentDiscovery,
     DiscoveryStrategy,
     create_default_strategy,
@@ -81,7 +81,7 @@ from genesis_agents.registry.discovery import (
 
 # Communication exports
 try:
-    from genesis_agents.communication.mcp_bridge import MCPBridge
+    from dynamus_agent.communication.mcp_bridge import MCPBridge
 except ImportError:
     # MCPBridge might depend on additional packages
     MCPBridge = None

--- a/dynamus-agent/src/dynamus_agent/registry/agent_registry.py
+++ b/dynamus-agent/src/dynamus_agent/registry/agent_registry.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/registry/agent_registry.py
+# src/dynamus_agent/registry/agent_registry.py
 """
 Registry central de agentes con auto-discovery - Hub Independiente
 
@@ -17,9 +17,9 @@ from pathlib import Path
 # DEPENDENCIA: Solo MCPturbo (hub independiente)
 from mcpturbo.agents import AgentRegistry as MCPAgentRegistry
 
-from genesis_agents.base.genesis_agent import GenesisAgent
-from genesis_agents.base.capabilities import AgentCapability, CapabilityCategory
-from genesis_agents.base.exceptions import AgentRegistryError, AgentDiscoveryError
+from dynamus_agent.agents.agent_base import GenesisAgent
+from dynamus_agent.agents.capabilities import AgentCapability, CapabilityCategory
+from dynamus_agent.agents.exceptions import AgentRegistryError, AgentDiscoveryError
 
 
 class GenesisAgentRegistry:
@@ -249,7 +249,7 @@ class GenesisAgentRegistry:
             self.capabilities_map[capability].append(agent_id)
             
             # Mapear por categoría
-            from genesis_agents.base.capabilities import get_capability_category
+            from dynamus_agent.agents.capabilities import get_capability_category
             category = get_capability_category(capability)
             if category not in self.category_map:
                 self.category_map[category] = []
@@ -280,7 +280,7 @@ class GenesisAgentRegistry:
             self.stats["agents_by_type"][agent_type] = self.stats["agents_by_type"].get(agent_type, 0) + 1
             
             # Por categorías
-            from genesis_agents.base.capabilities import get_capability_category
+            from dynamus_agent.agents.capabilities import get_capability_category
             categories = set(get_capability_category(cap) for cap in agent.get_capabilities())
             for category in categories:
                 cat_name = category.value

--- a/dynamus-agent/src/dynamus_agent/registry/discovery.py
+++ b/dynamus-agent/src/dynamus_agent/registry/discovery.py
@@ -1,4 +1,4 @@
-# src/genesis_agents/registry/discovery.py
+# src/dynamus_agent/registry/discovery.py
 """
 Auto-discovery de agentes en el ecosistema - Hub Independiente
 
@@ -15,7 +15,7 @@ from typing import List, Dict, Set, Optional
 from pathlib import Path
 import sys
 
-from genesis_agents.base.exceptions import AgentDiscoveryError
+from dynamus_agent.agents.exceptions import AgentDiscoveryError
 
 
 class AgentDiscovery:
@@ -58,7 +58,7 @@ class AgentDiscovery:
             "genesis_testing.agents",
             
             # Agentes built-in del hub
-            "genesis_agents.builtin",
+            "dynamus_agent.builtin",
         ]
         
         available_modules = []
@@ -143,8 +143,8 @@ class AgentDiscovery:
         try:
             import pkg_resources
             
-            # Buscar entry points del grupo 'genesis_agents'
-            for entry_point in pkg_resources.iter_entry_points('genesis_agents'):
+            # Buscar entry points del grupo 'dynamus_agent'
+            for entry_point in pkg_resources.iter_entry_points('dynamus_agent'):
                 try:
                     module_name = entry_point.module_name
                     discovered.append(module_name)


### PR DESCRIPTION
## Summary
- update imports to use `dynamus_agent` across agent and registry modules
- adjust comments and docstrings referencing `genesis_agents`
- align discovery entry point references with new module name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=src python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'mcpturbo')*


------
https://chatgpt.com/codex/tasks/task_e_689cbe2ec09883259b3af023ef9c8832