### PR TITLE
Use agent instance ID when registering

### DIFF
--- a/dynamus-agent/src/dynamus_agent/registry/registry.py
+++ b/dynamus-agent/src/dynamus_agent/registry/registry.py
@@ -3,12 +3,24 @@ class AgentRegistry:
 
     @classmethod
     def register(cls, agent_cls):
-        cls._registry[agent_cls.id] = agent_cls()
+        """Register an agent class.
+
+        The class must be instantiable without arguments and the resulting
+        instance must expose an ``agent_id`` attribute. The instance is stored
+        in the registry under this identifier.
+        """
+
+        agent = agent_cls()
+        cls._registry[agent.agent_id] = agent
 
     @classmethod
     def get(cls, agent_id):
+        """Retrieve a registered agent instance by its ``agent_id``."""
+
         return cls._registry.get(agent_id)
 
     @classmethod
     def all(cls):
+        """Return the mapping of ``agent_id`` to agent instances."""
+
         return cls._registry


### PR DESCRIPTION
## Summary
- Register agents using their instantiated `agent_id`
- Document expected agent format and access patterns

## Testing
- `ruff check dynamus-agent/src/dynamus_agent/registry/registry.py`
- `pytest dynamus-agent`


------
https://chatgpt.com/codex/tasks/task_e_689cbe2cc87c83259fc2d4e5c5d219ad