### PR TITLE
chore: remove unused imports from framework

### DIFF
--- a/dynamus-core/src/dynamus_core/framework.py
+++ b/dynamus-core/src/dynamus_core/framework.py
@@ -3,14 +3,11 @@
 # Framework base para generación de código
 # ============================================
 
-import os
-import json
-from typing import Dict, Any, List, Optional, Type, Union
+from typing import Dict, Any, List, Optional
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from jinja2 import Environment, FileSystemLoader, Template
 from pathlib import Path
-import importlib.util
 
 @dataclass
 class FieldDefinition:


### PR DESCRIPTION
## Summary
- drop unused os, json, and importlib imports from core framework
- clean up typing imports flagged by ruff

## Testing
- `ruff check dynamus-core/src/dynamus_core/framework.py`


------
https://chatgpt.com/codex/tasks/task_e_689cbe2b03688325a2851e714b4bba16