### PR TITLE
feat: add minimal CLI and version metadata

### DIFF
--- a/dynamus/pyproject.toml
+++ b/dynamus/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
   "dynamus-templates>=0.0.1"
 ]
 
+[project.scripts]
+dynamus = "dynamus.cli:main"
+
 [tool.setuptools]
 packages = { find = { where = ["src"] } }
 

--- a/dynamus/src/dynamus/__init__.py
+++ b/dynamus/src/dynamus/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for Dynamus."""
+
+__version__ = "0.0.1"
+
+from .cli import main  # noqa: E402,F401
+
+__all__ = ["__version__", "main"]
+

--- a/dynamus/src/dynamus/cli.py
+++ b/dynamus/src/dynamus/cli.py
@@ -1,0 +1,36 @@
+"""Command line interface for the Dynamus package."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from . import __version__
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the Dynamus command line interface.
+
+    Parameters
+    ----------
+    argv:
+        Optional sequence of arguments to parse instead of :data:`sys.argv`.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Dynamus command line interface",
+    )
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("task", nargs="?", help="Name of the task to run")
+
+    args = parser.parse_args(argv)
+
+    if args.task:
+        print(f"Running task: {args.task}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()
+


### PR DESCRIPTION
## Summary
- add basic CLI with argparse and version option
- expose package version and main entry in `__init__`
- register `dynamus` executable via project scripts

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a612c8fc248325a352ce106ff54dab